### PR TITLE
updated readme with new features and return empty df instead of crash…

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ print(quote.insider_trading_df)  # 0         WILKE JEFFREY A  ...  http://www.se
 ### Screener
 Information from https://finviz.com/screener.ashx?ft=4. The Screener class uses 
 ALL the options (dropdowns) in the webpage mentioned in the last sentence (over 60), and uses
-view options (OVERVIEW, VALUATION, ..., CUSTOM). You can also specify a range of pages to fetch.
+view options (OVERVIEW, VALUATION, ..., CUSTOM). Added signals filter too. You can also specify a range of pages to fetch.
+
+Returns an empty dataframe if there are no results.
+
 ```python
 from pyfinviz.screener import Screener
 

--- a/pyfinviz/utils.py
+++ b/pyfinviz/utils.py
@@ -46,6 +46,8 @@ class WebScraper:
     def get_single_table_pandas(main_url):
         soup = WebScraper.get_soup(main_url)
         td = soup.find("td", {"class": "table-top"})
+        if td is None:
+            return soup, pd.DataFrame()
         main_table_rows = td.find_parent("table").find_all("tr")
         table_header = [re.sub(r'[^a-zA-Z0-9]', '', td.text.strip()) for td in
                         main_table_rows[0].find_all("td", recursive=False)]


### PR DESCRIPTION
This PR handles the edge case in which if there are no tables to turn into a df. If the screener's filter is too specific, it will return a nasty error and crash. Returning an empty df seems to be more elegant.

<img width="1388" alt="Screenshot 2023-08-10 at 10 10 44 AM" src="https://github.com/oscar0812/pyfinviz/assets/6497318/2d655eab-f42c-495c-b0a8-2bc8817eec62">
